### PR TITLE
TPTOR-2834

### DIFF
--- a/__tests__/es/schedule.test.js
+++ b/__tests__/es/schedule.test.js
@@ -11,18 +11,16 @@ describe('schedule', function() {
     expect(Object.keys(buildSchedule(airings, interval, startTime, endTime)).length).toEqual(Math.ceil(1440 / interval));
   });
 
-  it('for all channel schedule returns (1 day / interval rows) * number of channels', function() {
+  it('for all channel schedule each channel contains (1 day / interval rows)', function() {
     let airings = mockAllChannelAirings();
     let startTime = moment(airings[0].data.date * 1000).tz("America/Chicago").startOf('day').unix();
     let endTime = moment(airings[0].data.date * 1000).tz("America/Chicago").endOf('day').unix();
     let interval = (Math.floor(Math.random() * 12) + 1) * 5;
     let schedule = buildSchedule(airings, interval, startTime, endTime);
 
-    for (var k in schedule) {
-      if (schedule.hasOwnProperty(k)) {
-        expect(Object.keys(schedule[k]).length).toEqual(Math.ceil(1440 / interval));
-      }
-    }
+    schedule.forEach( function(value) {
+      expect(value.airings.length).toEqual(Math.ceil(1440 / interval));
+    });
   });
 
   it('empty timeslots fill with previous slot episode', function() {
@@ -39,10 +37,7 @@ describe('schedule', function() {
     let endTime = moment(airings[0].data.date * 1000).tz("America/Chicago").endOf('day').unix();
     let interval = 30;
     let schedule = buildSchedule(airings, interval, startTime, endTime);
-    let keys = Object.keys(schedule);
-    let firstElement = schedule[keys[0]];
-    let lastElement = schedule[keys[keys.length-1]];
-    expect(firstElement).toEqual(lastElement);
+    expect(schedule[0]).toEqual(schedule.pop());
   });
 
   it('"Nothing Scheduled" row if first timeslot has no entry', function() {

--- a/handler.js
+++ b/handler.js
@@ -7,6 +7,7 @@ import mapToAirings from './src/parse/protrack';
 import actions from './src/es/actions';
 import buildSchedule from './src/es/schedule';
 import normalize from './src/results';
+import { normalizeSchedule } from './src/results';
 import moment from "moment-timezone";
 
 function p(event: Object, key: string): string {
@@ -148,7 +149,7 @@ export function schedule_channel(event: Object, context: Object) {
       let airings = buildSchedule(result, p(event,'granularity'), start, end);
       return {
         statusCode: 200,
-        body: JSON.stringify(airings),
+        body: JSON.stringify(normalizeSchedule(airings, options.channel)),
         headers: {
           'Content-Type': 'application/json',
         }

--- a/handler.js
+++ b/handler.js
@@ -117,7 +117,7 @@ export function schedule(event: Object, context: Object) {
     let airings = buildSchedule(result, p(event,'granularity'), start, end);
     return {
       statusCode: 200,
-      body: JSON.stringify(airings),
+      body: JSON.stringify(normalizeSchedule(airings)),
       headers: {
         'Content-Type': 'application/json',
       }
@@ -149,7 +149,7 @@ export function schedule_channel(event: Object, context: Object) {
       let airings = buildSchedule(result, p(event,'granularity'), start, end);
       return {
         statusCode: 200,
-        body: JSON.stringify(normalizeSchedule(airings, options.channel)),
+        body: JSON.stringify(normalizeSchedule(airings, true)),
         headers: {
           'Content-Type': 'application/json',
         }

--- a/src/results.js
+++ b/src/results.js
@@ -1,13 +1,27 @@
 import { normalize as normalizer, schema } from 'normalizr';
 
-let show = new schema.Entity('show');
-let episode = new schema.Entity('episode');
-let airing = new schema.Entity('airing', { show, episode }, {
+const show = new schema.Entity('show');
+const episode = new schema.Entity('episode', {}, {
+  idAttribute: function(episode) {
+    return episode.id || parseInt(`${episode.program.id}${episode.version.id}`);
+  }
+});
+const airing = new schema.Entity('airing', { show, episode }, {
   idAttribute: function(airing) {
     return `${airing.channel}.${airing.date}`;
   }
 });
+const channel = new schema.Entity('channel', { airings: [airing] });
 
 export default function normalize(results) {
   return normalizer(results.map(r => r.data), [airing]);
+}
+
+export function normalizeSchedule(results, singleChannel = false) {
+  if (singleChannel) {
+    return results;
+    return normalizer(results, [airing]);
+  } else {
+    return normalizer(results, [channel]);
+  }
 }

--- a/src/results.js
+++ b/src/results.js
@@ -19,7 +19,6 @@ export default function normalize(results) {
 
 export function normalizeSchedule(results, singleChannel = false) {
   if (singleChannel) {
-    return results;
     return normalizer(results, [airing]);
   } else {
     return normalizer(results, [channel]);


### PR DESCRIPTION
Seems to work fine -- single channel result is an array of airing ids, multi channel result is an array of channels (with each channel entity having an array of airing ids).

As mentioned I wasn't getting an episode id back in search results (as expected since ff3ff08056b40e2289eac0d19152903e9ab3e459).  I'm putting it in on-the-fly as a derived idAttribute in /src/results.js:10 .

